### PR TITLE
fix: Fix coordinate lookup

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@ const path = require('path');
 const turf = require('./turf');
 
 const GEO_GENERATED_FILE_PATH = path.resolve(__dirname, 'geo.generated.json');
+const MAX_NEAREST_ZONE_DISTANCE_KM = 50; // Maximum distance in km to consider a zone as "nearest" for reverse geocoding, used to allow for some leeway in case the coordinates are just outside the coastline.
 
 /**
  * Loads the geometry features from disk for reverse geocoding.
@@ -13,7 +14,6 @@ async function loadGeometryFeatures() {
     if (!_geoFeaturePromise) {
         // NOTE we do this async as the file is huge and will block the main thread
         // for several seconds.
-        const tStart = new Date().getTime();
         _geoFeaturePromise = new Promise((resolve, reject) => {
             fs.readFile(GEO_GENERATED_FILE_PATH, (err, data) => {
                 if (err) {
@@ -61,8 +61,6 @@ function getNearestZone({ potentialZones, zoneToLines, targetPoint }) {
 let _geoFeaturePromise = null;
 
 async function reverseGeocode(lon, lat) {
-    const tStart = new Date().getTime();
-
     const { convexhulls, zoneToGeometryFeatures, zoneToLines } = await loadGeometryFeatures();
 
     const targetPoint = turf.point([lon, lat]);


### PR DESCRIPTION
This pull request introduces a new constant for reverse geocoding and removes unnecessary timing-related code to streamline the `utils.js` file. The most important changes include defining a maximum distance for determining the nearest zone and cleaning up unused variables.

### Reverse geocoding improvement:
* Added `MAX_NEAREST_ZONE_DISTANCE_KM` constant to define the maximum distance (50 km) for considering a zone as "nearest" during reverse geocoding. This provides flexibility for coordinates near coastlines. (`utils.js`, [utils.jsR6](diffhunk://#diff-fda8f0e13abe3d5c5685ad895fa528dd6067c41b66b6ebc6d1de71ca9a704d8dR6))

### Code cleanup:
* Removed the unused `tStart` variable from the `loadGeometryFeatures` function, which was previously used for timing but is no longer necessary. (`utils.js`, [utils.jsL16](diffhunk://#diff-fda8f0e13abe3d5c5685ad895fa528dd6067c41b66b6ebc6d1de71ca9a704d8dL16))
* Removed the unused `tStart` variable from the `reverseGeocode` function, simplifying the code. (`utils.js`, [utils.jsL64-L65](diffhunk://#diff-fda8f0e13abe3d5c5685ad895fa528dd6067c41b66b6ebc6d1de71ca9a704d8dL64-L65))